### PR TITLE
Add non-subsampled color format for h264 encoder

### DIFF
--- a/include/FFmpegUtilities.h
+++ b/include/FFmpegUtilities.h
@@ -122,6 +122,9 @@
 	#ifndef PIX_FMT_YUV420P
 		#define PIX_FMT_YUV420P AV_PIX_FMT_YUV420P
 	#endif
+	#ifndef PIX_FMT_YUV444P
+		#define PIX_FMT_YUV444P AV_PIX_FMT_YUV444P
+	#endif
 
 	// FFmpeg's libavutil/common.h defines an RSHIFT incompatible with Ruby's
 	// definition in ruby/config.h, so we move it to FF_RSHIFT

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -438,6 +438,7 @@ void FFmpegWriter::SetOption(StreamType stream, std::string name, std::string va
 						av_opt_set_int(c->priv_data, "qp", std::min(std::stoi(value), 51), 0); // 0-51
 						if (std::stoi(value) == 0) {
 							av_opt_set(c->priv_data, "preset", "veryslow", 0);
+							c->pix_fmt = PIX_FMT_YUV444P; // no chroma subsampling
 						}
 						break;
 					case AV_CODEC_ID_HEVC :
@@ -497,6 +498,7 @@ void FFmpegWriter::SetOption(StreamType stream, std::string name, std::string va
 						av_opt_set_int(c->priv_data, "crf", std::min(std::stoi(value), 51), 0); // 0-51
 						if (std::stoi(value) == 0) {
 							av_opt_set(c->priv_data, "preset", "veryslow", 0);
+							c->pix_fmt = PIX_FMT_YUV444P; // no chroma subsampling
 						}
 						break;
 					case AV_CODEC_ID_HEVC :


### PR DESCRIPTION
Forces the 4:4:4 color format for "0 crf" and "0 cqp" setting of the
H264 encoder. By default, the 4:2:0 is used, that is not lossless
itself.